### PR TITLE
make it possible to disable whitespace cleanup

### DIFF
--- a/KSPasswordField.h
+++ b/KSPasswordField.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSInteger, PasswordMeter) {
 
 @property(nonatomic) BOOL showStrength;
 @property(nonatomic) BOOL showMatchIndicator;
+@property (nonatomic) IBInspectable BOOL cleanUpWhitespace;
 @property(nonatomic) PasswordMeter passwordMeter;
 
 /**

--- a/KSPasswordField.m
+++ b/KSPasswordField.m
@@ -327,6 +327,7 @@ NSRect drawAdornments(NSRect cellFrame, NSView *controlView)
     if (self = [super initWithFrame:frameRect])
     {
         _becomesFirstResponderWhenToggled = YES;
+        _cleanUpWhitespace = YES;
 
 		// Don't show text by default. This needs to be called to replace the standard cell with our custom one.
 		[self setShowsText:NO];
@@ -339,6 +340,7 @@ NSRect drawAdornments(NSRect cellFrame, NSView *controlView)
     if (self = [super initWithCoder:aDecoder])
     {
         _becomesFirstResponderWhenToggled = YES;
+        _cleanUpWhitespace = YES;
 
 		// Don't show text by default. This needs to be called to replace the standard cell with our custom one.
 		[self setShowsText:NO];
@@ -514,7 +516,8 @@ NSRect drawAdornments(NSRect cellFrame, NSView *controlView)
 {
     BOOL shouldChange = YES;
     BOOL changingEntireContents = (affectedCharRange.location == 0) && (affectedCharRange.length == [textView.string length]);
-    if (changingEntireContents)
+
+    if (changingEntireContents && self.cleanUpWhitespace)
     {
         // we check for text containing non-whitespace characters but starting with or ending with whitespace
         // if we find it, we assume that it's being pasted in, and we trim the whitespace off first


### PR DESCRIPTION
The whitespace cleanup feature can be useful, but it can also be dangerous. Users won’t be aware that something like this is happening, so it might lead to confusion or even data loss in rare cases. For example, if this view is added to an app that had a normal password field before and users already have passwords set up that happen to have leading or trailing whitespace, they won’t be able to log in after an update if they’re copying the password from some other place.

For this reason, I think it’s reasonable to let the developer at least opt out of this feature.
