### PR TITLE
fixed revealed text moving up & down if showStrength is off

### DIFF
--- a/KSPasswordField.m
+++ b/KSPasswordField.m
@@ -207,7 +207,12 @@ NSRect drawAdornments(NSRect cellFrame, NSView *controlView)
 - (void)drawInteriorWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
 {
     cellFrame = drawAdornments(cellFrame, controlView);
-    cellFrame.origin.y -= 1;
+
+    if ([(KSPasswordField *)controlView showStrength])
+    {
+        cellFrame.origin.y -= 1;
+    }
+
     [super drawInteriorWithFrame:cellFrame inView:controlView];
 }
 


### PR DESCRIPTION
Without this adjustment, if the `showStrength` property is set to false on a password field and `showsText` is true, the displayed text moves up and down by 1 pixel when you tab into and out of the field. (See commit https://github.com/karelia/SecurityInterface/commit/3f23acc68fda3d3048b66e675b87fd268a722918)
